### PR TITLE
feat: add context7 documentation retrieval skill

### DIFF
--- a/scripts/audit.sh
+++ b/scripts/audit.sh
@@ -48,7 +48,8 @@ audit_target() {
   local source="$1" audit_target="$2"
 
   local audit_json
-  audit_json=$(skillshare audit "$audit_target" --threshold high --json 2>/dev/null) || true
+  # Strip trailing non-JSON output (e.g. upgrade notices) before parsing
+  audit_json=$(skillshare audit "$audit_target" --threshold high --json 2>/dev/null | sed '/^$/,$d') || true
 
   if ! echo "$audit_json" | jq -e '.summary' >/dev/null 2>&1; then
     local audit_err

--- a/skills/community.json
+++ b/skills/community.json
@@ -42,6 +42,15 @@
     ]
   },
   {
+    "name": "context7",
+    "description": "Retrieve up-to-date documentation for software libraries by querying the Context7 API",
+    "source": "intellectronica/agent-skills/skills/context7",
+    "tags": [
+      "docs",
+      "ai"
+    ]
+  },
+  {
     "name": "create-auth-skill",
     "description": "Create custom authentication skills using Better Auth framework",
     "source": "better-auth/skills/create-auth-skill",

--- a/skillshare-hub.json
+++ b/skillshare-hub.json
@@ -12,7 +12,7 @@
     {
       "name": "agent-browser",
       "description": "Browser automation agent for web page interactions using Playwright",
-      "source": "vercel-labs/agent-browser",
+      "source": "vercel-labs/agent-browser/skills/agent-browser",
       "tags": [
         "agent",
         "browser"
@@ -134,6 +134,15 @@
       "source": "coreyhaines31/marketingskills/content-strategy",
       "tags": [
         "marketing"
+      ]
+    },
+    {
+      "name": "context7",
+      "description": "Retrieve up-to-date documentation for software libraries by querying the Context7 API",
+      "source": "intellectronica/agent-skills/skills/context7",
+      "tags": [
+        "docs",
+        "ai"
       ]
     },
     {


### PR DESCRIPTION
## Summary
- Add `context7` skill from [intellectronica/agent-skills](https://github.com/intellectronica/agent-skills) to community registry
- Enables retrieval of up-to-date documentation for software libraries via the Context7 API
- Source: https://skills.sh/intellectronica/agent-skills/context7

## Test plan
- [ ] Verify `community.json` is valid JSON
- [ ] Verify alphabetical ordering is maintained
- [ ] CI build passes