### PR TITLE
Add Skills宝 to intro

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 </p>
 
 <p align="center">
+  For Chinese users, [Skills宝](https://skilery.com) is another place to discover and install skills.
+</p>
+
+<p align="center">
   <a href="https://github.com/runkids/skillshare-hub/blob/main/skillshare-hub.json"><img src="https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Frunkids%2Fskillshare-hub%2Fmain%2Fskillshare-hub.json&query=%24.skills.length&label=skills&color=blue" alt="Skill Count"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
 </p>


### PR DESCRIPTION
Adds Skills宝 as a Chinese-language skills discovery and install entry. The repository is already a curated skills catalog and internal hub reference, so this is a natural localized discovery link.