### PR TITLE
Add offload to the community skill catalog

### DIFF
--- a/skills/community.json
+++ b/skills/community.json
@@ -505,7 +505,7 @@
   },
   {
     "name": "offload",
-    "description": "Delegate bounded implementation and research work with orchestrator review",
+    "description": "Bounded implementation and research with pre-delegation offers and orchestrator review",
     "source": "anthonyandrei/offload",
     "tags": [
       "workflow",

--- a/skills/community.json
+++ b/skills/community.json
@@ -504,6 +504,16 @@
     ]
   },
   {
+    "name": "offload",
+    "description": "Delegate bounded implementation and research work with orchestrator review",
+    "source": "anthonyandrei/offload",
+    "tags": [
+      "workflow",
+      "agents",
+      "research"
+    ]
+  },
+  {
     "name": "openclaw-secure-linux-cloud",
     "description": "Openclaw Secure Linux Cloud skill for AI agent workflows",
     "source": "xixu-me/skills/openclaw-secure-linux-cloud",
@@ -759,16 +769,6 @@
     "source": "mattpocock/skills/zoom-out",
     "tags": [
       "workflow"
-    ]
-  },
-  {
-    "name": "offload",
-    "description": "Delegate parallel coding, research, and review work to headless agy workers with verified outputs",
-    "source": "anthonyandrei/offload",
-    "tags": [
-      "workflow",
-      "agents",
-      "research"
     ]
   }
 ]

--- a/skills/community.json
+++ b/skills/community.json
@@ -760,5 +760,15 @@
     "tags": [
       "workflow"
     ]
+  },
+  {
+    "name": "offload",
+    "description": "Delegate parallel coding, research, and review work to headless agy workers with verified outputs",
+    "source": "anthonyandrei/offload",
+    "tags": [
+      "workflow",
+      "agents",
+      "research"
+    ]
   }
 ]


### PR DESCRIPTION
## Summary

- Add `anthonyandrei/offload` to the community skill catalog.
- Describe bounded implementation and research work with pre-delegation offers and orchestrator review.
- Tag it for workflow, agents, and research discovery.

The skill is public and distributed under the MIT license. It discovers current worker tools at runtime, with worker, model, and effort choices kept runtime-dynamic.

## Validation

- `skills/community.json` parses as valid JSON.
- The entry follows the documented community catalog schema.
- The repository validator reaches an unrelated existing sort failure in `skills/antfu.json`; the same failure is present on the base branch.

## Source contract

The catalog entry matches the source skill's current contract. Offload offers once before native multi-agent delegation for two or more independent, bounded assignments, requires consent before dispatch, and lets native delegation continue after a decline.